### PR TITLE
Return after encountering errors in windows write

### DIFF
--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -369,6 +369,7 @@ void EIO_Write(uv_work_t* req) {
 		if(lastError != ERROR_IO_PENDING) {
 		  // Write operation error
 		  ErrorCodeToString("Writing to COM port (WriteFile)", lastError, data->errorString);
+		  return;
 		}
 		else {
 		  // Write operation is asynchronous and is pending
@@ -381,6 +382,7 @@ void EIO_Write(uv_work_t* req) {
 			// Write operation error
 			DWORD lastError = GetLastError();
 			ErrorCodeToString("Writing to COM port (GetOverlappedResult)", lastError, data->errorString);
+			return;
 		  }
 		  else {
 			// Write operation completed asynchronously


### PR DESCRIPTION
The unix version breaks the while loop by returning on certain errors. On Windows, the errors were being contained because the while loop was never breaking. For example, pulling the USB cable out would raise `Access Denied` errors but the while loop would run forever and contain that error.
